### PR TITLE
Header merge control (#95) and column-wise pagination span fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: clinify
 Type: Package
 Title: Clinical Table Styling Tools and Utilities
-Version: 0.3.1
+Version: 0.4.0
 Authors@R: c(
     person(given = "Mike",
            family = "Stackhouse",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# clinify (development version)
+# clinify 0.4.0
 
 - `clin_column_headers()` gained a `merge` argument to control the automatic merging of identical, adjacent header cells. Use `merge = "spanners"` to keep the bottom row of the header out of it, `merge = FALSE` to turn merging off entirely, or a vector of header row numbers for finer control. This lets a header row that legitimately repeats a label across adjacent columns keep those cells separate ([#95](https://github.com/atorus-research/clinify/issues/95))
 - `clin_column_headers()` can now be called with only the `merge` argument and no header text, which adjusts the merging of headers already in place - including headers built from column labels ([#95](https://github.com/atorus-research/clinify/issues/95))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# clinify (development version)
+
+- `clin_column_headers()` gained a `merge` argument to control the automatic merging of identical, adjacent header cells. Use `merge = "spanners"` to keep the bottom row of the header out of it, `merge = FALSE` to turn merging off entirely, or a vector of header row numbers for finer control. This lets a header row that legitimately repeats a label across adjacent columns keep those cells separate ([#95](https://github.com/atorus-research/clinify/issues/95))
+- `clin_column_headers()` can now be called with only the `merge` argument and no header text, which adjusts the merging of headers already in place - including headers built from column labels ([#95](https://github.com/atorus-research/clinify/issues/95))
+- The `clinify_table_default()` in `defaults_template.R` no longer merges header cells horizontally, which would have overridden the `merge` argument of `clin_column_headers()` at render time
+- Because `merge` is now a parameter of `clin_column_headers()`, a column named `merge` can no longer be given a header through `...`. Use column labels for that column instead. This is a breaking change.
+- Fixed merged cells being left in an invalid state when a table is paginated column wise with `clin_alt_pages()`. Merges are now recalculated for every row of the header, for the table body, and for merges running vertically, where previously only the top header row was corrected. Symptoms included header text disappearing from later pages, cells claiming to span more columns than the page has, and `write_clindoc()` failing with "missing value where TRUE/FALSE needed" when a page ended in a split spanner
+- Fixed a single column table losing all but the top level of a multi level column header
+
 # clinify 0.3.1
 
 - Updated for compatibility with {officer} (>= 0.7.0); the minimum required {officer} version is now 0.7.2

--- a/R/clintable.R
+++ b/R/clintable.R
@@ -57,8 +57,9 @@ as_clintable <- function(x, page_by = NULL, group_by = NULL) {
 #' @param group_by A character vector of variable names which will be used for grouping and attached
 #'   as a label above the table headers
 #' @param use_labels Use variable labels as column headers. Nested levels can be
-#'   achieved using the string "||" as a delimitter. Horizontal and vertical levels
-#'   using identical words will be merged.
+#'   achieved using the string "||" as a delimitter. Horizontally adjacent cells
+#'   using identical words will be merged, which can be adjusted afterwards using
+#'   the `merge` argument of `clin_column_headers()`.
 #' @param ... Parameters to pass to `flextable::flextable()`
 #'
 #' @return A clintable object

--- a/R/column_headers.R
+++ b/R/column_headers.R
@@ -11,17 +11,43 @@
 #' to the bottom. So a column with two levels will apply to the
 #' second and third row, and a column with one level with apply
 #' the bottom row. Spanners are determined using cells of the same
-#' text value, where horizontal and vertical merging is performed.
+#' text value, where horizontally adjacent cells holding the same
+#' text are merged. Use the `merge` argument when a header row
+#' legitimately repeats a label across adjacent columns and those
+#' cells should be left alone. `merge` works a row at a time, so if a
+#' single row needs some of its repeated cells merged but not others,
+#' leave that row out of `merge` and span the intended cells with
+#' `flextable::merge_at()`.
 #'
 #' The same result can be achieved using column labels on the
 #' input dataframe to the clintable. If labels are present,
 #' header levels will be separated using the delimitter "||" within
-#' the label string.
+#' the label string. Headers built that way can have their merging
+#' adjusted by calling `clin_column_headers()` with no header text and
+#' only the `merge` argument, which leaves the header text as it is.
+#' Called that way, any merging already on the header is cleared first -
+#' including merges applied by hand with `flextable::merge_at()` or
+#' `flextable::merge_v()` - so the rows named in `merge` end up being the
+#' only merged rows.
 #'
 #' @param x A clintable object
 #' @param ... Named arguments providing the column header text.
 #'   Separate levels of the header are determined using separate
 #'   elements of a character vector.
+#' @param merge Controls the automatic merging of identical, adjacent
+#'   header cells, which is what forms spanners. `TRUE` (the default) or
+#'   `"all"` merges every header row, `FALSE` or `"none"` merges none of
+#'   them, and `"spanners"` merges every row except the bottom one - the
+#'   row holding the individual column labels. Merging can also be
+#'   limited to specific header rows, numbered from the top down, using
+#'   ordinary R subscripts: `merge = 1:2` merges the top two rows only,
+#'   `merge = -3` merges every row except the third, and a logical vector
+#'   as long as the header is deep toggles each row individually. Only
+#'   the header is ever merged - the table body is left alone.
+#'
+#'   One thing to know: a custom `clinify_table_default()` that calls
+#'   `flextable::merge_h()` on the header will merge it again when the
+#'   table renders, overriding whatever is set here.
 #'
 #' @return A clintable object
 #'
@@ -36,25 +62,142 @@
 #'     Petal.Width = c("Petal", "Width")
 #'   )
 #'
-clin_column_headers <- function(x, ...) {
+#' # Keep the repeated bottom row cells separate, but still span
+#' # "Flowers" and "Petal" across the columns above them
+#' clintable(iris) |>
+#'   clin_column_headers(
+#'     Sepal.Length = c("Flowers", "Sepal", "Value"),
+#'     Sepal.Width = c("Flowers", "Sepal", "Value"),
+#'     Petal.Length = c("Petal", "Value"),
+#'     Petal.Width = c("Petal", "Value"),
+#'     merge = "spanners"
+#'   )
+#'
+#' # Headers coming from column labels can have their merging adjusted
+#' # without restating the header text
+#' iris2 <- iris
+#' attr(iris2$Sepal.Length, "label") <- "Flowers||Value"
+#' attr(iris2$Sepal.Width, "label") <- "Flowers||Value"
+#'
+#' clintable(iris2) |>
+#'   clin_column_headers(merge = 1)
+#'
+clin_column_headers <- function(x, ..., merge = TRUE) {
   stopifnot(inherits(x, "clintable"))
-  refdat <- x$body$dataset
 
-  # Pull out the column widths
-  args <- list(...)
-  if (!all(vapply(args, is.character, TRUE))) {
-    stop("All header arguments must be characters")
+  # A column of the data named `merge` would be claimed by that parameter, so
+  # there is no telling a header for it apart from a merging instruction
+  if (!missing(merge) && "merge" %in% colnames(x$body$dataset)) {
+    stop(
+      "The `merge` argument cannot be used on a clintable that has a column ",
+      "named `merge`. Set that column's header using column labels instead ",
+      "(see the `use_labels` argument of `clintable()`)."
+    )
   }
+
+  # Pull out the header text
+  args <- list(...)
+  hint <- merge_hint_(names(args), colnames(x$body$dataset))
+
+  if (!all(vapply(args, is.character, TRUE))) {
+    stop("All header arguments must be characters", hint)
+  }
+
+  if (!all(names(args) %in% colnames(x$body$dataset))) {
+    stop(
+      "All argument names must be columns present within the clintable columns",
+      hint
+    )
+  }
+
+  # Without any header text there's nothing to build, so take it as a request
+  # to re-apply the merging rules to the headers already in place. This is how
+  # headers built from column labels are adjusted.
+  if (length(args) == 0) {
+    return(remerge_header_(x, merge))
+  }
+
+  apply_column_headers_(x, args, merge)
+}
+
+#' Fill the unused levels of one column's header
+#'
+#' Blanks are padded with a single space when the column has something in
+#' it, and left empty when the whole column is blank. That is what keeps an
+#' entirely blank column from merging into the padding of the column beside
+#' it, which in turn keeps the bottom border off it.
+#'
+#' @param x The header levels of one column, unused levels being `NA`
+#'
+#' @return The header levels with the blanks filled in
+#'
+#' @noRd
+fill_header_blanks_ <- function(x) {
+  if (all(is.na(x)) || any(x != "", na.rm = TRUE)) {
+    x[is.na(x)] <- " "
+  } else {
+    x[is.na(x)] <- ""
+  }
+  x
+}
+
+#' Nudge towards `merge` when a header argument looks like a misspelling of it
+#'
+#' `merge` follows `...`, so R will not partially match it. A near miss on
+#' the name silently becomes header text for a column that doesn't exist,
+#' which is worth pointing out.
+#'
+#' @param nms Names of the header arguments that were supplied
+#' @param cols Columns of the clintable
+#'
+#' @return A sentence to append to an error message, or an empty string
+#'
+#' @noRd
+merge_hint_ <- function(nms, cols) {
+  # A name that really is a column of the data is not a misspelling
+  nms <- setdiff(nms[nzchar(nms)], cols)
+  nms <- tolower(nms)
+
+  near_miss <- (startsWith("merge", nms) & nchar(nms) >= 3) |
+    startsWith(nms, "merge")
+
+  if (any(near_miss)) {
+    paste(
+      ". Did you mean `merge`? Arguments that follow `...` have to be",
+      "named in full"
+    )
+  } else {
+    ""
+  }
+}
+
+#' Apply a set of column headers to a clintable
+#'
+#' Shared workhorse of `clin_column_headers()` and
+#' `headers_from_labels_()`. Header text arrives as a list rather than
+#' through `...` so that a variable named the same as one of the
+#' function parameters can still be given a header.
+#'
+#' @param x A clintable object
+#' @param args A named list of character vectors of header text
+#' @param merge Header rows to merge, as documented in `clin_column_headers()`
+#'
+#' @return A clintable object
+#'
+#' @noRd
+apply_column_headers_ <- function(x, args, merge = TRUE) {
+  refdat <- x$body$dataset
 
   if (!all(names(args) %in% colnames(refdat))) {
     stop("All argument names must be columns present within the clintable columns")
   }
 
-  # Get header depth
-  max(vapply(args, length, 1))
-
   # Find how many header levels are necessary
   depth <- max(vapply(args, length, 1))
+
+  if (depth < 1) {
+    stop("Column headers must have at least one level")
+  }
 
   # Create a matrix for the headers
   mheaders <- matrix(nrow = depth, ncol = ncol(refdat))
@@ -71,51 +214,171 @@ clin_column_headers <- function(x, ...) {
     }
   }
 
-  # Fill the characters
-  mheaders <- as.matrix(apply(mheaders, 2, \(x) {
-    # Play games with  whitespace to get cell merging to work
-    # for bottom borders
-    if (all(is.na(x)) || any(x != "", na.rm = TRUE)) {
-      x[is.na(x)] <- " "
-    } else {
-      x[is.na(x)] <- ""
-    }
-    x
-  }))
+  # Fill the characters. Rebuilding the matrix by hand rather than leaning on
+  # what apply() gives back keeps the shape the same whether the header is one
+  # level deep or the table is one column wide
+  mheaders <- matrix(
+    unlist(
+      lapply(seq_len(ncol(mheaders)), \(j) fill_header_blanks_(mheaders[, j])),
+      use.names = FALSE
+    ),
+    nrow = depth,
+    ncol = ncol(refdat)
+  )
 
-  # Single column headers will read as a column
-  # Multi row need to be transposed
-  if (dim(mheaders)[2] > 1) {
-    tmheaders <- t(mheaders)
-  } else {
-    tmheaders <- mheaders
-  }
-
-  typology <- as.data.frame(tmheaders, row.names = FALSE)
+  # The typology wants a row per column of the table
+  typology <- as.data.frame(t(mheaders), row.names = FALSE)
   typology["col_keys"] <- colnames(refdat)
 
-
   # Apply to the clintable
-  x |>
-    flextable::set_header_df(typology) |>
-    flextable::merge_h(part = "header")
+  x <- flextable::set_header_df(x, typology)
+
+  # Merging is resolved against the header rows that actually landed on the
+  # table, which is not always the number of levels asked for
+  remerge_header_(x, merge, clear = FALSE)
+}
+
+#' Merge the rows of a header that is already in place
+#'
+#' Rows are resolved against the header rows the table actually has,
+#' rather than the number of levels the caller asked for - the two are
+#' not always the same. Used directly when `clin_column_headers()` is
+#' given no header text, which leaves the header text alone and only
+#' changes which rows have their identical, adjacent cells merged.
+#'
+#' @param x A clintable object
+#' @param merge Header rows to merge, as documented in `clin_column_headers()`
+#' @param clear Clear any merging already in place first, so the requested
+#'   rows end up being the only merged rows
+#'
+#' @return A clintable object
+#'
+#' @noRd
+remerge_header_ <- function(x, merge, clear = TRUE) {
+  depth <- nrow(x$header$dataset)
+
+  if (depth < 1) {
+    stop(
+      "Column headers cannot be merged because the clintable has no header rows"
+    )
+  }
+
+  merge_rows <- unique(resolve_header_merge_(merge, depth))
+
+  if (clear) {
+    x <- flextable::merge_none(x, part = "header")
+
+    # merge_none() hands back doubles where the rest of the header spans are
+    # integers, which would leave two equivalent routes comparing unequal
+    storage.mode(x$header$spans$rows) <- "integer"
+    storage.mode(x$header$spans$columns) <- "integer"
+  }
+
+  if (length(merge_rows) > 0) {
+    x <- flextable::merge_h(x, i = merge_rows, part = "header")
+  }
+
+  x
+}
+
+#' Keywords accepted by the `merge` argument
+#' @noRd
+merge_keywords_ <- c("all", "none", "spanners")
+
+#' Message for a `merge` value that is not something we can work with
+#' @noRd
+merge_type_msg_ <- paste0(
+  "`merge` must be TRUE, FALSE, ",
+  paste(sprintf('"%s"', merge_keywords_), collapse = ", "),
+  ", or a vector of header row numbers"
+)
+
+#' Resolve the `merge` argument into header row numbers
+#'
+#' Standard R subscript semantics are used against the header rows, so
+#' `TRUE`/`FALSE` select all or none, positive numbers select rows from
+#' the top down, negative numbers drop rows, and a logical vector as
+#' long as the header is deep toggles each row.
+#'
+#' @param merge The user provided `merge` value
+#' @param depth The number of header rows
+#'
+#' @return An integer vector of header rows to merge
+#'
+#' @noRd
+resolve_header_merge_ <- function(merge, depth) {
+  if (is.null(merge)) {
+    stop("`merge` cannot be NULL. ", merge_type_msg_)
+  }
+
+  # Keywords say what the merging is for rather than where it lands, so they
+  # hold up when a header gains or loses a level
+  if (is.character(merge)) {
+    if (length(merge) != 1 || !merge %in% merge_keywords_) {
+      stop(merge_type_msg_)
+    }
+
+    return(switch(
+      merge,
+      all = seq_len(depth),
+      none = integer(0),
+      spanners = seq_len(depth - 1)
+    ))
+  }
+
+  if (!is.logical(merge) && !is.numeric(merge)) {
+    stop(merge_type_msg_)
+  }
+
+  if (length(merge) == 0 || anyNA(merge)) {
+    stop("`merge` cannot be empty or contain missing values")
+  }
+
+  if (is.logical(merge)) {
+    if (!length(merge) %in% c(1, depth)) {
+      stop(sprintf(
+        "A logical `merge` must be length 1 or length %s (the number of header rows), not %s",
+        depth,
+        length(merge)
+      ))
+    }
+  } else {
+    if (any(merge != trunc(merge))) {
+      stop("`merge` header row numbers must be whole numbers")
+    }
+    if (any(merge > 0) && any(merge < 0)) {
+      stop("`merge` cannot mix positive and negative header row numbers")
+    }
+    if (any(merge == 0)) {
+      stop("`merge` header row numbers cannot be 0 - header rows count from 1")
+    }
+    if (any(abs(merge) > depth)) {
+      stop(sprintf(
+        "`merge` header row numbers must be between 1 and %s (the number of header rows)",
+        depth
+      ))
+    }
+  }
+
+  seq_len(depth)[merge]
 }
 
 #' Convert column labels into column headers
 #'
 #' This function will look at the column labels, and if present
 #' separate the header levels using the delimitter "||" within
-#' the label string. Header setup is done using the exported
-#' function `clin_column_headers()`. Spanners are determined
-#' using cells of the same text value, where horizontal and
-#' vertical merging is performed.
+#' the label string. Header setup is done using the same machinery as
+#' the exported function `clin_column_headers()`. Spanners are
+#' determined using cells of the same text value, where horizontally
+#' adjacent cells holding the same text are merged.
 #'
 #' @param x A clintable object
+#' @param merge Header rows to merge, as documented in `clin_column_headers()`
 #'
 #' @return A clintable object
 #'
 #' @noRd
-headers_from_labels_ <- function(x) {
+headers_from_labels_ <- function(x, merge = TRUE) {
   refdat <- x$body$dataset
   if (has_labels_(refdat)) {
     args <- lapply(refdat, \(x) {
@@ -126,9 +389,8 @@ headers_from_labels_ <- function(x) {
       }
     })
 
-    args <- append(args, list(x = x), after = 0)
     # Build header df from the labels
-    do.call(clin_column_headers, args)
+    apply_column_headers_(x, args, merge)
   } else {
     # Just return the object if no labels
     x

--- a/R/pagination.R
+++ b/R/pagination.R
@@ -424,7 +424,7 @@ prep_pagination_ <- function(x) {
       refdat
     )
     cols <- seq(1:ncol(refdat))[-key_idx]
-    x <- slice_clintable(x, 1:nrow(refdat), cols, skip_spans = TRUE)
+    x <- slice_clintable(x, 1:nrow(refdat), cols)
   }
 
   # Make Column vectors

--- a/R/slice_clintable.R
+++ b/R/slice_clintable.R
@@ -8,7 +8,6 @@
 #' @param x A clintable or flextable object
 #' @param rows Subset of rows to extract
 #' @param columns Subset of columns to extract
-#' @param skip_spans Don't readjust spanners in the header
 #' @param reapply_config Carry the clinify config to the sliced page
 #'
 #' @return A clinpage object
@@ -22,7 +21,6 @@ slice_clintable <- function(
   x,
   rows,
   columns,
-  skip_spans = FALSE,
   reapply_config = FALSE
 ) {
   out <- new_clinpage()
@@ -61,77 +59,77 @@ slice_clintable <- function(
   out$blanks <- x$blanks
   out$properties <- x$properties
 
-  # If the column headers have spanners, then it's possible
-  # the horizontal span is too wide for the vector
-  if (!skip_spans && nrow(x$header$dataset) > 0) {
-    for (i in seq_along(dim(out$header$spans$rows)[1])) {
-      out$header$spans$rows[i, ] <- adjust_span_row(
-        out$header$spans$rows[i, ],
-        out$header$dataset[i, ]
-      )
-    }
+  out
+}
+
+#' Subset the merges of a table part
+#'
+#' Merged cells are stored as a count on the first cell of the merge and a
+#' zero on each cell it covers, so taking a subset of rows or columns out of
+#' the middle of a merge leaves counts that no longer match what is there -
+#' too wide, or a covered cell whose count has been dropped along with the
+#' cell that carried it. Working out which merge each cell belongs to first
+#' and then counting the cells that survive gives the merges the subset
+#' should have.
+#'
+#' Horizontal merges are the ones a column subset disturbs, and vertical
+#' merges are the ones a row subset disturbs.
+#'
+#' @param spans The `spans` element of a table part
+#' @param rows Subset of rows
+#' @param columns Subset of cols
+#'
+#' @return A `spans` list holding the merges of the subset
+#'
+#' @noRd
+slice_spans <- function(spans, rows, columns) {
+  out <- list(
+    rows = matrix(1L, nrow = length(rows), ncol = length(columns)),
+    columns = matrix(1L, nrow = length(rows), ncol = length(columns))
+  )
+
+  # Carry the numeric type of the source table forward
+  storage.mode(out$rows) <- storage.mode(spans$rows)
+  storage.mode(out$columns) <- storage.mode(spans$columns)
+
+  for (i in seq_along(rows)) {
+    out$rows[i, ] <- slice_span_vec(spans$rows[rows[i], ], columns)
+  }
+
+  for (j in seq_along(columns)) {
+    out$columns[, j] <- slice_span_vec(spans$columns[, columns[j]], rows)
   }
 
   out
 }
 
-#' Adjust Row Spanning Over Page Breaks
+#' Subset one row or column of merges
 #'
-#' This function modifies a vector `v` representing row spans in a table. It ensures that
-#' spans are correctly adjusted over page breaks by identifying cases where data values exist (`d`),
-#' but spans are incorrectly set to 0. The function updates such cases to maintain consistency.
+#' @param v Merge counts along one row or column of a table part
+#' @param keep The positions being kept
 #'
-#' @param v A numeric vector representing row spans.
-#' @param d A character vector representing the data values in the table.
-#' @return A modified numeric vector with adjusted row spans.
+#' @return The merge counts of the kept positions
+#'
 #' @examples
-#' v <- c(0, 0, 2, 0, 0)
-#' d <- c("A", "A", "B", "B", "B")
-#' adjust_span_row(v, d) # Corrects the spans accordingly
+#' # A blank pair of cells followed by a spanner over four
+#' slice_span_vec(c(2, 0, 4, 0, 0, 0), c(1, 2, 3)) # 2 0 1
 #' @noRd
-adjust_span_row <- function(v, d) {
-  # Find and update spans over page breaks by finding
-  # data values populated but spans are set as 0
-  not_empty <- !(d %in% c(" ", ""))
-  if (any(not_empty)) {
-    ne_ind <- which(not_empty)
-
-    indices <- which(diff(ne_ind) == 1) # Find indices where the difference is 1
-    unique_starts <- indices[which(diff(indices) != 1)]
-
-    # Include the first element if it starts a sequence
-    if (length(indices) > 0 && indices[1] == 1) {
-      unique_starts <- c(ne_ind[1], unique_starts)
-    }
-
-    for (i in unique_starts) {
-      # Set it to 2 and this will correct in the next step
-      if (v[i] == 0) v[i] <- 2
-    }
+slice_span_vec <- function(v, keep) {
+  if (!length(keep)) {
+    return(v[0])
   }
 
-  for (i in seq_along(v)) {
-    if (
-      (
-        # Contains multi span and not the last element and not, or
-        (v[i] > 0 && i < length(v) && v[i] != 1) ||
-          # The last element is 1 but this one is 0, so this is spanned
-          (i == 1 || v[i - 1] == 1) && v[i] == 0
-      ) &&
-        # Followed by 0
-        v[i + 1] == 0
-    ) {
-      # Count consecutive zeros after v[i]
-      count_zeros <- sum(cumsum(v[-(1:i)]) == 0)
-      v[i] <- count_zeros + 1
-    } else {
-      # For the last element don't span extra
-      if (i == length(v) && v[i] > 1) {
-        v[i] <- 1
-      }
-    }
-  }
-  return(v)
+  # Each count opens a merge and each zero continues the one before it, so
+  # the position of the count identifies the merge every cell belongs to
+  blocks <- cummax(seq_along(v) * (v > 0))
+
+  # Count the cells of each merge that survived, and put the count back on
+  # the first of them
+  kept <- rle(blocks[keep])$lengths
+  unlist(
+    lapply(kept, \(n) c(n, rep(0L, n - 1L))),
+    use.names = FALSE
+  )
 }
 
 #' Slice a complex_tabpart object
@@ -161,9 +159,7 @@ slice_complex_tabpart <- function(x, rows, columns) {
   hrule <- x$hrule[rows]
 
   # Spans
-  spans <- x$spans
-  spans$rows <- spans$rows[rows, columns, drop = FALSE]
-  spans$columns <- spans$columns[rows, columns, drop = FALSE]
+  spans <- slice_spans(x$spans, rows, columns)
 
   # Styles
   styles <- list(cells = NULL, pars = NULL, text = NULL)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,15 +1,14 @@
 ## Submission notes
 
-This is a patch release (0.3.1) that fixes the R CMD check ERROR reported for
-clinify 0.3.0 on r-devel-linux-x86_64-fedora-gcc.
+This is a minor release (0.4.0). It adds a `merge` argument to
+`clin_column_headers()` so that automatic merging of identical, adjacent
+column header cells can be limited to chosen header rows, and it fixes cell
+merges being left in an invalid state when a table is paginated column wise.
+See NEWS.md.
 
-The failure was in a unit test that compared {flextable} `autofit()` row
-heights for exact equality. Those heights are estimated from font metrics and
-vary across platforms, which produced a single-row mismatch (0.433 vs 0.422)
-on r-devel-linux-x86_64-fedora-gcc only. The test no longer asserts on those
-platform-dependent dimensions; it still verifies table data, content, spans,
-styles, and headers. This release also brings compatibility with
-{officer} (>= 0.7.0) and several styling/slicing fixes; see NEWS.md.
+One narrow breaking change is documented in NEWS.md: because `merge` is now a
+parameter of `clin_column_headers()`, a column named `merge` can no longer be
+given a header through `...`.
 
 ## Test environments
 
@@ -19,13 +18,10 @@ styles, and headers. This release also brings compatibility with
 
 ## R CMD check results
 
-0 errors | 0 warnings | 1 note
+0 errors | 0 warnings | 0 notes
 
-The package checks cleanly (0 errors, 0 warnings) on all of the GitHub Actions
-environments listed above, including R-devel on Linux. The only NOTE appears
-locally: "checking for future file timestamps ... unable to verify current
-time", which is caused by the local check machine having no network access to
-verify the current time; it does not occur on CRAN.
+Checked locally on macOS with R 4.5.1. The GitHub Actions environments listed
+above are checked on every push; confirm they are green before submitting.
 
 ## Reverse dependencies
 

--- a/inst/defaults_template.R
+++ b/inst/defaults_template.R
@@ -101,7 +101,7 @@ options(
   },
   #' The function to apply default table styling
   #'
-  #' Headers with the same value are merged both horizontally and vertically
+  #' Headers stacked with the same value are merged vertically
   #' All borders are clear except for the header (bleck, solid, 0.2pt)
   #' As well as top horizontal line for the table header.
   #' font style - Courier New, 9pt, not bold, not italic
@@ -117,10 +117,11 @@ options(
   #' @export
   clinify_table_default = function(x, ...) {
 
-    # Merge cells with same name
-    # (merge occurs both horizontally and vertically)
+    # Merge cells stacked with the same name.
+    # Horizontal merging is left alone here - that is decided when the headers
+    # are built, and merging again would override the `merge` argument of
+    # clin_column_headers().
     x <- flextable::merge_v(x, part="header")
-    x <- flextable::merge_h(x, part="header")
 
 
     # You can center-align all table headers but first, for example like this:

--- a/man/clin_column_headers.Rd
+++ b/man/clin_column_headers.Rd
@@ -4,7 +4,7 @@
 \alias{clin_column_headers}
 \title{Set the column headers of the output clintable}
 \usage{
-clin_column_headers(x, ...)
+clin_column_headers(x, ..., merge = TRUE)
 }
 \arguments{
 \item{x}{A clintable object}
@@ -12,6 +12,21 @@ clin_column_headers(x, ...)
 \item{...}{Named arguments providing the column header text.
 Separate levels of the header are determined using separate
 elements of a character vector.}
+
+\item{merge}{Controls the automatic merging of identical, adjacent
+header cells, which is what forms spanners. \code{TRUE} (the default) or
+\code{"all"} merges every header row, \code{FALSE} or \code{"none"} merges none of
+them, and \code{"spanners"} merges every row except the bottom one - the
+row holding the individual column labels. Merging can also be
+limited to specific header rows, numbered from the top down, using
+ordinary R subscripts: \code{merge = 1:2} merges the top two rows only,
+\code{merge = -3} merges every row except the third, and a logical vector
+as long as the header is deep toggles each row individually. Only
+the header is ever merged - the table body is left alone.
+
+One thing to know: a custom \code{clinify_table_default()} that calls
+\code{flextable::merge_h()} on the header will merge it again when the
+table renders, overriding whatever is set here.}
 }
 \value{
 A clintable object
@@ -28,13 +43,25 @@ one or two, the columns with less levels to the header will bind
 to the bottom. So a column with two levels will apply to the
 second and third row, and a column with one level with apply
 the bottom row. Spanners are determined using cells of the same
-text value, where horizontal and vertical merging is performed.
+text value, where horizontally adjacent cells holding the same
+text are merged. Use the \code{merge} argument when a header row
+legitimately repeats a label across adjacent columns and those
+cells should be left alone. \code{merge} works a row at a time, so if a
+single row needs some of its repeated cells merged but not others,
+leave that row out of \code{merge} and span the intended cells with
+\code{flextable::merge_at()}.
 }
 \details{
 The same result can be achieved using column labels on the
 input dataframe to the clintable. If labels are present,
 header levels will be separated using the delimitter "||" within
-the label string.
+the label string. Headers built that way can have their merging
+adjusted by calling \code{clin_column_headers()} with no header text and
+only the \code{merge} argument, which leaves the header text as it is.
+Called that way, any merging already on the header is cleared first -
+including merges applied by hand with \code{flextable::merge_at()} or
+\code{flextable::merge_v()} - so the rows named in \code{merge} end up being the
+only merged rows.
 }
 \examples{
 
@@ -45,5 +72,25 @@ clintable(iris) |>
     Petal.Length = c("Petal", "Length"),
     Petal.Width = c("Petal", "Width")
   )
+
+# Keep the repeated bottom row cells separate, but still span
+# "Flowers" and "Petal" across the columns above them
+clintable(iris) |>
+  clin_column_headers(
+    Sepal.Length = c("Flowers", "Sepal", "Value"),
+    Sepal.Width = c("Flowers", "Sepal", "Value"),
+    Petal.Length = c("Petal", "Value"),
+    Petal.Width = c("Petal", "Value"),
+    merge = "spanners"
+  )
+
+# Headers coming from column labels can have their merging adjusted
+# without restating the header text
+iris2 <- iris
+attr(iris2$Sepal.Length, "label") <- "Flowers||Value"
+attr(iris2$Sepal.Width, "label") <- "Flowers||Value"
+
+clintable(iris2) |>
+  clin_column_headers(merge = 1)
 
 }

--- a/man/clintable.Rd
+++ b/man/clintable.Rd
@@ -15,8 +15,9 @@ clintable(x, page_by = NULL, group_by = NULL, use_labels = TRUE, ...)
 as a label above the table headers}
 
 \item{use_labels}{Use variable labels as column headers. Nested levels can be
-achieved using the string "||" as a delimitter. Horizontal and vertical levels
-using identical words will be merged.}
+achieved using the string "||" as a delimitter. Horizontally adjacent cells
+using identical words will be merged, which can be adjusted afterwards using
+the \code{merge} argument of \code{clin_column_headers()}.}
 
 \item{...}{Parameters to pass to \code{flextable::flextable()}}
 }

--- a/tests/testthat/test-column_headers.R
+++ b/tests/testthat/test-column_headers.R
@@ -8,6 +8,465 @@ test_that("Errors checking", {
 
   # Proper column names
   expect_error(clin_column_headers(clintable(iris), blah = "blah"), "All argument names")
+
+  # Header levels have to hold something
+  expect_error(
+    clin_column_headers(clintable(iris), Species = character(0)),
+    "at least one level"
+  )
+
+  # Nothing to merge without a header
+  expect_error(
+    clin_column_headers(
+      flextable::delete_part(clintable(iris), part = "header"),
+      merge = FALSE
+    ),
+    "no header rows"
+  )
+})
+
+test_that("merge can be adjusted without restating the header text", {
+  # Labels are the other way headers get built, and until now they had no way
+  # to opt out of the merging (#95)
+  dat <- data.frame(a = "1", b = "2", c = "3")
+  attr(dat$a, "label") <- "Spanner||Baseline"
+  attr(dat$b, "label") <- "Spanner||Baseline"
+  attr(dat$c, "label") <- "Other||Baseline"
+
+  ct <- clintable(dat)
+  labeled_text <- ct$header$dataset
+
+  # Default merging collapses the shared bottom level
+  expect_equal(ct$header$spans$rows[2, ], c(3, 0, 0))
+
+  # Keeping the spanner but not the leaves
+  ct2 <- clin_column_headers(ct, merge = 1)
+  expect_equal(ct2$header$spans$rows[1, ], c(2, 0, 1))
+  expect_equal(ct2$header$spans$rows[2, ], c(1, 1, 1))
+
+  # The header text itself is untouched
+  expect_equal(ct2$header$dataset, labeled_text)
+
+  # Merging can be dropped entirely, and re-applied afterwards. Coming back
+  # this way has to land on exactly what building the header produced
+  ct3 <- clin_column_headers(ct2, merge = FALSE)
+  expect_equal(ct3$header$spans$rows, matrix(1, nrow = 2, ncol = 3))
+  expect_identical(clin_column_headers(ct3, merge = TRUE), ct)
+
+  # Merging the whole header is cleared out first, including merges the user
+  # applied themselves
+  by_hand <- flextable::merge_at(ct3, i = 1:2, j = 1, part = "header")
+  expect_equal(by_hand$header$spans$columns[, 1], c(2, 0))
+  expect_equal(
+    clin_column_headers(by_hand, merge = FALSE)$header$spans$columns,
+    matrix(1, nrow = 2, ncol = 3)
+  )
+
+  # Only the header is ever touched. Body merges have to come through every
+  # merge value intact
+  bodied <- flextable::merge_at(ct, i = 1, j = 2:3, part = "body")
+  expect_equal(bodied$body$spans$rows[1, ], c(1, 2, 0))
+
+  for (m in list(TRUE, FALSE, 1, "spanners", "none")) {
+    adjusted <- clin_column_headers(bodied, merge = m)
+    expect_equal(adjusted$body$spans, bodied$body$spans, info = format(m))
+    expect_equal(adjusted$body$dataset, bodied$body$dataset, info = format(m))
+  }
+})
+
+test_that("merge argument is validated", {
+  ct <- clintable(iris)
+  headers <- function(...) {
+    clin_column_headers(
+      ct,
+      Sepal.Length = c("Flowers", "Sepal", "Length"),
+      Sepal.Width = c("Flowers", "Sepal", "Width"),
+      Petal.Length = c("Petal", "Length"),
+      Petal.Width = c("Petal", "Width"),
+      Species = "",
+      ...
+    )
+  }
+
+  # Only keywords, logicals and numbers are row selectors
+  expect_error(headers(merge = "1"), "must be TRUE, FALSE")
+  expect_error(headers(merge = c("all", "none")), "must be TRUE, FALSE")
+  expect_error(headers(merge = list(1)), "must be TRUE, FALSE")
+  expect_error(headers(merge = factor(3)), "must be TRUE, FALSE")
+
+  # NULL is not a stand in for the default
+  expect_error(headers(merge = NULL), "cannot be NULL")
+
+  # Missings and empties are never intentional
+  expect_error(headers(merge = NA), "cannot be empty or contain missing")
+  expect_error(headers(merge = c(1, NA)), "cannot be empty or contain missing")
+  expect_error(headers(merge = integer(0)), "cannot be empty or contain missing")
+
+  # Logical vectors have to line up with the header rows
+  expect_error(headers(merge = c(TRUE, FALSE)), "must be length 1 or length 3")
+
+  # Row numbers have to be usable row numbers
+  expect_error(headers(merge = 1.5), "must be whole numbers")
+  expect_error(headers(merge = c(-1, 2)), "cannot mix positive and negative")
+  expect_error(headers(merge = 0), "cannot be 0")
+  expect_error(headers(merge = 4), "must be between 1 and 3")
+  expect_error(headers(merge = -4), "must be between 1 and 3")
+
+  # `merge` follows the dots, so a near miss on the name becomes header text
+  expect_error(headers(mer = FALSE), "Did you mean `merge`", fixed = TRUE)
+  expect_error(headers(merges = FALSE), "Did you mean `merge`", fixed = TRUE)
+
+  # Including when the value looks like a keyword, which lands on the unknown
+  # column name error rather than the type error
+  expect_error(headers(Merge = "spanners"), "Did you mean `merge`", fixed = TRUE)
+  expect_error(headers(merg = "all"), "Did you mean `merge`", fixed = TRUE)
+
+  # But a real column of the data is never a misspelling of `merge`
+  expect_error(
+    clin_column_headers(clintable(iris), Species = 1),
+    "^All header arguments must be characters$"
+  )
+  merged <- data.frame(m = "1", merged = "2")
+  expect_error(
+    clin_column_headers(clintable(merged, use_labels = FALSE), merged = 1),
+    "^All header arguments must be characters$"
+  )
+})
+
+test_that("Default merge behavior is unchanged by the merge argument", {
+  ct <- clintable(iris)
+  headers <- function(...) {
+    clin_column_headers(
+      ct,
+      Sepal.Length = c("Flowers", "Sepal", "Length"),
+      Sepal.Width = c("Flowers", "Sepal", "Width"),
+      Petal.Length = c("Petal", "Length"),
+      Petal.Width = c("Petal", "Width"),
+      Species = "",
+      ...
+    )
+  }
+
+  # Every way of saying "merge everything" has to land in the same place,
+  # including the pre-existing behavior of merging the whole header part
+  reference <- headers() |>
+    flextable::merge_none(part = "header") |>
+    flextable::merge_h(part = "header")
+
+  expect_equal(headers(), reference)
+  expect_equal(headers(merge = TRUE), reference)
+  expect_equal(headers(merge = "all"), reference)
+  expect_equal(headers(merge = 1:3), reference)
+  expect_equal(headers(merge = c(TRUE, TRUE, TRUE)), reference)
+})
+
+test_that("merge argument controls which header rows merge", {
+  ct <- clintable(iris)
+
+  # The bottom row repeats a label across adjacent columns, which is what makes
+  # the merge value observable at all
+  headers <- function(...) {
+    clin_column_headers(
+      ct,
+      Sepal.Length = c("Flowers", "Sepal", "Value"),
+      Sepal.Width = c("Flowers", "Sepal", "Value"),
+      Petal.Length = c("Petal", "Value"),
+      Petal.Width = c("Petal", "Value"),
+      Species = "",
+      ...
+    )
+  }
+
+  unmerged <- matrix(1, nrow = 3, ncol = 5)
+
+  # Merging everything collapses that bottom row, so the assertions below
+  # distinguish "all rows" from "all rows but the last"
+  expect_equal(headers()$header$spans$rows[3, ], c(4, 0, 0, 0, 1))
+
+  # Nothing merges
+  expect_equal(headers(merge = FALSE)$header$spans$rows, unmerged)
+  expect_equal(headers(merge = "none")$header$spans$rows, unmerged)
+
+  # Only the top row merges, three equivalent ways of asking
+  top_only <- unmerged
+  top_only[1, ] <- c(2, 0, 2, 0, 1)
+  expect_equal(headers(merge = 1)$header$spans$rows, top_only)
+  expect_equal(headers(merge = -(2:3))$header$spans$rows, top_only)
+  expect_equal(
+    headers(merge = c(TRUE, FALSE, FALSE))$header$spans$rows,
+    top_only
+  )
+
+  # Everything but the bottom row, which is how repeated leaf labels are kept
+  # separate (#95)
+  no_leaf <- unmerged
+  no_leaf[1:2, ] <- c(2, 2, 0, 0, 2, 2, 0, 0, 1, 1)
+  expect_equal(headers(merge = 1:2)$header$spans$rows, no_leaf)
+  expect_equal(headers(merge = -3)$header$spans$rows, no_leaf)
+  expect_equal(headers(merge = c(TRUE, TRUE, FALSE))$header$spans$rows, no_leaf)
+  expect_equal(headers(merge = "spanners")$header$spans$rows, no_leaf)
+
+  # Single level headers are still row 1
+  flat <- function(...) {
+    clin_column_headers(
+      ct,
+      Sepal.Length = "Sepal",
+      Sepal.Width = "Sepal",
+      Petal.Length = "Petal",
+      Petal.Width = "Petal",
+      Species = "Species",
+      ...
+    )
+  }
+  expect_equal(
+    flat(merge = FALSE)$header$spans$rows,
+    matrix(1, nrow = 1, ncol = 5)
+  )
+
+  # A single row header is all leaves, so there are no spanners to merge
+  expect_equal(
+    flat(merge = "spanners")$header$spans$rows,
+    matrix(1, nrow = 1, ncol = 5)
+  )
+  expect_equal(
+    flat(merge = 1)$header$spans$rows,
+    matrix(c(2, 0, 2, 0, 1), nrow = 1)
+  )
+})
+
+test_that("A one column table takes a multi level header", {
+  # Every level asked for has to reach the table, and merging is resolved
+  # against the header rows the table really ends up with
+  one_col <- data.frame(a = 1:3)
+
+  for (m in list(TRUE, FALSE, 1, -1, "all", "none", "spanners")) {
+    ct <- clin_column_headers(
+      clintable(one_col),
+      a = c("Top", "Bottom"),
+      merge = m
+    )
+    expect_equal(nrow(ct$header$dataset), 2)
+    expect_equal(unname(unlist(ct$header$dataset)), c("Top", "Bottom"))
+
+    # One column has nothing to merge with
+    expect_equal(ct$header$spans$rows, matrix(1L, nrow = 2, ncol = 1))
+    expect_equal(ct$header$spans$columns, matrix(1L, nrow = 2, ncol = 1))
+  }
+
+  # Deeper headers land the same way
+  deep <- clin_column_headers(clintable(one_col), a = c("A", "B", "C"))
+  expect_equal(unname(unlist(deep$header$dataset)), c("A", "B", "C"))
+
+  # Same through the labels path
+  labeled <- data.frame(a = 1:3)
+  attr(labeled$a, "label") <- "Top||Bottom"
+  ct <- clintable(labeled)
+  expect_equal(unname(unlist(ct$header$dataset)), c("Top", "Bottom"))
+
+  # And it still renders
+  expect_no_error(clintable_as_html(ct))
+  expect_no_error(write_clindoc(ct, file = withr::local_tempfile(fileext = ".docx")))
+
+  # Row numbers are held to the header rows that are really there
+  expect_error(
+    clin_column_headers(clintable(one_col), a = c("Top", "Bottom"), merge = 3),
+    "must be between 1 and 2"
+  )
+
+  # Asking for the same row twice is harmless. The columns left out of the call
+  # come through blank, and blanks merge with each other
+  ct <- clintable(iris)
+  expect_equal(
+    clin_column_headers(
+      ct,
+      Sepal.Length = c("Flowers", "Length"),
+      Sepal.Width = c("Flowers", "Width"),
+      merge = c(1, 1)
+    )$header$spans$rows[1, ],
+    c(2, 0, 3, 0, 0)
+  )
+})
+
+test_that("Repeated leaf labels can be kept separate (#95)", {
+  # The shape that motivated the issue - adjacent columns legitimately share
+  # a bottom level label underneath their own spanners
+  dat <- data.frame(
+    lbl = "Row label",
+    a_base = "1", a_post = "2",
+    b_base = "3", b_post = "4"
+  )
+
+  ct <- clintable(dat, use_labels = FALSE) |>
+    clin_column_headers(
+      lbl = "",
+      a_base = c("Treatment A", "Baseline"),
+      a_post = c("Treatment A", "Post"),
+      b_base = c("Treatment B", "Baseline"),
+      b_post = c("Treatment B", "Post"),
+      merge = 1
+    )
+
+  # Spanners merged on the top row, leaves untouched on the bottom
+  expect_equal(
+    ct$header$spans$rows,
+    matrix(
+      c(
+        1, 2, 0, 2, 0,
+        1, 1, 1, 1, 1
+      ),
+      nrow = 2,
+      byrow = TRUE
+    )
+  )
+
+  # Same layout, but now the shared leaf label really is adjacent
+  ct2 <- clintable(dat, use_labels = FALSE) |>
+    clin_column_headers(
+      lbl = "",
+      a_base = c("Treatment A", "Baseline"),
+      a_post = c("Treatment A", "Baseline"),
+      b_base = c("Treatment B", "Baseline"),
+      b_post = c("Treatment B", "Baseline"),
+      merge = 1
+    )
+
+  # All four "Baseline" cells stay separate, which is what the default
+  # merge would have collapsed into one cell
+  expect_equal(ct2$header$spans$rows[2, ], c(1, 1, 1, 1, 1))
+  expect_equal(ct2$header$spans$rows[1, ], c(1, 2, 0, 2, 0))
+
+  default_merge <- clintable(dat, use_labels = FALSE) |>
+    clin_column_headers(
+      lbl = "",
+      a_base = c("Treatment A", "Baseline"),
+      a_post = c("Treatment A", "Baseline"),
+      b_base = c("Treatment B", "Baseline"),
+      b_post = c("Treatment B", "Baseline")
+    )
+  expect_equal(default_merge$header$spans$rows[2, ], c(1, 4, 0, 0, 0))
+})
+
+test_that("The merge choice carries through to the rendered output", {
+  # Skipping the merge also skips flextable's own merge bookkeeping, so the
+  # object has to be proven renderable rather than just inspectable
+  dat <- data.frame(
+    lbl = "Row label",
+    a_base = "1", a_post = "2",
+    b_base = "3", b_post = "4"
+  )
+
+  headers <- function(...) {
+    clintable(dat, use_labels = FALSE) |>
+      clin_column_headers(
+        lbl = "",
+        a_base = c("Treatment", "Baseline"),
+        a_post = c("Treatment", "Baseline"),
+        b_base = c("Treatment", "Baseline"),
+        b_post = c("Treatment", "Baseline"),
+        ...
+      )
+  }
+
+  # Word is the first class output, so count the spans officer really wrote
+  grid_spans <- function(ct) {
+    file <- withr::local_tempfile(fileext = ".docx")
+    write_clindoc(ct, file = file)
+
+    unzipped <- withr::local_tempdir()
+    utils::unzip(file, files = "word/document.xml", exdir = unzipped)
+    xml <- readLines(
+      file.path(unzipped, "word", "document.xml"),
+      warn = FALSE
+    )
+    sum(lengths(regmatches(xml, gregexpr("gridSpan", xml, fixed = TRUE))))
+  }
+
+  # Both header rows collapse by default, so Word gets one span per row
+  expect_equal(grid_spans(headers()), 2)
+
+  # Only the spanner row collapses, leaving one
+  expect_equal(grid_spans(headers(merge = "spanners")), 1)
+
+  # With merging off every header cell stands alone, so there are none at all
+  expect_equal(grid_spans(headers(merge = FALSE)), 0)
+
+  # The HTML preview path has to survive it too
+  expect_no_error(clintable_as_html(headers(merge = FALSE)))
+  expect_no_error(clintable_as_html(headers(merge = "spanners")))
+})
+
+test_that("Unmerged header rows survive slicing", {
+  # Slicing repairs spanners split over column page breaks, and that repair
+  # must not re-merge cells the user asked to keep separate
+  dat <- as.data.frame(matrix(1:12, nrow = 2))
+  names(dat) <- c("key", paste0("v", 1:5))
+
+  ct <- clintable(dat, use_labels = FALSE) |>
+    clin_alt_pages(
+      key_cols = "key",
+      # The last page holds a single column, which is where the spanner loses
+      # the cell carrying its merge count
+      col_groups = list(c("v1", "v2"), c("v3", "v4"), "v5")
+    ) |>
+    clin_column_headers(
+      key = c("", "Key"),
+      v1 = c("Spanner", "Baseline"),
+      v2 = c("Spanner", "Baseline"),
+      v3 = c("Spanner", "Baseline"),
+      v4 = c("Spanner", "Baseline"),
+      v5 = c("Spanner", "Baseline"),
+      merge = 1
+    )
+
+  ct2 <- prep_pagination_(ct)
+  pages <- ct2$clinify_config$pagination_idx
+  expect_length(pages, 3)
+
+  for (p in pages) {
+    sliced <- slice_clintable(ct2, p$rows, p$cols)
+    width <- length(p$cols)
+
+    # The spanner is cut by the column break and gets repaired
+    expect_equal(
+      sliced$header$spans$rows[1, ],
+      c(1L, width - 1L, rep(0L, width - 2L)),
+      info = paste("cols:", paste(p$cols, collapse = ","))
+    )
+    # The bottom row was never merged, so every cell stays on its own
+    expect_equal(
+      sliced$header$spans$rows[2, ],
+      rep(1L, width),
+      info = paste("cols:", paste(p$cols, collapse = ","))
+    )
+  }
+})
+
+test_that("A column named merge can still be given a header", {
+  dat <- data.frame(merge = "a", other = "b")
+
+  # Through the dots the argument is claimed by the merge parameter, so the
+  # user gets pointed at the way out
+  # Every value is refused, so the collision can never be silently swallowed
+  for (m in list("Merged", "none", "all", "spanners", 1, TRUE, FALSE, -1)) {
+    expect_error(
+      clin_column_headers(clintable(dat, use_labels = FALSE), merge = m),
+      "cannot be used on a clintable that has a column named `merge`",
+      fixed = TRUE
+    )
+  }
+
+  # Leaving it out still works, and that column just goes unheaded
+  expect_no_error(
+    clin_column_headers(clintable(dat, use_labels = FALSE), other = "Other")
+  )
+
+  # Labels sidestep the collision entirely
+  attr(dat$merge, "label") <- "Spanner||Merged"
+  attr(dat$other, "label") <- "Spanner||Other"
+  ct <- clintable(dat)
+
+  expect_equal(unname(unlist(ct$header$dataset[2, ])), c("Merged", "Other"))
+  expect_equal(ct$header$spans$rows[1, ], c(2, 0))
 })
 
 test_that("Headers apply as expected", {

--- a/tests/testthat/test-slice_clintable.R
+++ b/tests/testthat/test-slice_clintable.R
@@ -110,48 +110,333 @@ test_that("Basic table subset works", {
   testthat::expect_equal(z$body, y$body, ignore_attr = TRUE)
 })
 
-test_that("Spanning header adjustment function works", {
-  # simulate a split two split pages and one circumstance
-  # where a spanner is cut midway through
-  in_v <- t(matrix(
-    c(
-      9, 0, 0, 5, 0, 5,
-      9, 0, 0, 5, 0, 5,
-      0, 0, 0, 5, 0, 5,
-      1, 0, 0, 5, 0, 5,
-      4, 0, 0, 0, 0, 0
-    ),
-    nrow = 6, ncol = 5
-  ))
+test_that("Subsetting merges keeps the merges the subset should have", {
+  # Two blank cells merged together, then a spanner over four
+  v <- c(2L, 0L, 4L, 0L, 0L, 0L)
 
-  in_d <- t(matrix(
-    c(
-      rep("", 6),
-      rep("", 6),
-      rep("", 6),
-      rep("", 6),
-      c("", "", "A", "A", "A", "A")
-    ),
-    nrow = 6, ncol = 5
-  ))
+  # Keeping everything changes nothing
+  expect_equal(slice_span_vec(v, 1:6), v)
 
-  # All the outputs should be the same
-  exp_out_v <- t(matrix(
-    c(
-      3, 0, 0, 2, 0, 1,
-      3, 0, 0, 2, 0, 1,
-      3, 0, 0, 2, 0, 1,
-      1, 2, 0, 2, 0, 1,
-      2, 0, 4, 0, 0, 0
-    ),
-    nrow = 6, ncol = 5
-  ))
+  # A merge that loses some of its cells narrows to what is left
+  expect_equal(slice_span_vec(v, 1:3), c(2L, 0L, 1L))
+  expect_equal(slice_span_vec(v, 1:4), c(2L, 0L, 2L, 0L))
 
-  adjusted_v <- matrix(NA_real_, nrow = 5, ncol = 6)
+  # A merge that loses the cell carrying its count keeps the count on the
+  # first cell that survived, rather than leaving it stranded
+  expect_equal(slice_span_vec(v, 3:6), c(4L, 0L, 0L, 0L))
+  expect_equal(slice_span_vec(v, 4:6), c(3L, 0L, 0L))
+  expect_equal(slice_span_vec(v, c(2, 4)), c(1L, 1L))
 
-  for (i in 1:5) {
-    adjusted_v[i, ] <- adjust_span_row(in_v[i, ], in_d[i, ])
+  # Cells of one merge come back together when what sat between them is gone
+  expect_equal(slice_span_vec(v, c(1, 2, 5, 6)), c(2L, 0L, 2L, 0L))
+
+  # Down to a single cell there is nothing left to merge
+  expect_equal(slice_span_vec(v, 6), 1L)
+  expect_equal(slice_span_vec(v, 1), 1L)
+
+  # Nothing to keep
+  expect_equal(slice_span_vec(v, integer(0)), integer(0))
+
+  # Cells that were never merged are never merged for us, whatever they hold.
+  # This is what keeps clin_column_headers(merge = ) from being undone by
+  # pagination
+  expect_equal(slice_span_vec(rep(1L, 6), c(1, 2, 3)), rep(1L, 3))
+  expect_equal(slice_span_vec(rep(1L, 6), c(1, 4, 6)), rep(1L, 3))
+})
+
+test_that("Subset merges are always well formed", {
+  # A merge count has to be followed by exactly that many fewer cells, and the
+  # counts have to add up to the width of the table
+  well_formed <- function(v) {
+    i <- 1L
+    while (i <= length(v)) {
+      if (is.na(v[i]) || v[i] < 1 || i + v[i] - 1L > length(v)) {
+        return(FALSE)
+      }
+      if (v[i] > 1L && any(v[(i + 1L):(i + v[i] - 1L)] != 0)) {
+        return(FALSE)
+      }
+      i <- i + v[i]
+    }
+    TRUE
   }
 
-  expect_equal(adjusted_v, exp_out_v)
+  # Every arrangement of merges across a row, for every width up to 5
+  span_rows <- function(n) {
+    if (n == 0) {
+      return(list(integer(0)))
+    }
+    out <- list()
+    for (first in 1:n) {
+      for (rest in span_rows(n - first)) {
+        out[[length(out) + 1]] <- as.integer(c(first, rep(0L, first - 1L), rest))
+      }
+    }
+    out
+  }
+
+  checked <- 0
+  for (n in 1:5) {
+    for (v in span_rows(n)) {
+      for (mask in 1:(2^n - 1)) {
+        keep <- which(bitwAnd(mask, 2^(seq_len(n) - 1)) > 0)
+        out <- slice_span_vec(v, keep)
+        checked <- checked + 1
+        expect_length(out, length(keep))
+        expect_true(
+          well_formed(out),
+          label = paste0(
+            "spans c(", paste(v, collapse = ","), ") kept ",
+            paste(keep, collapse = ","), " gave c(",
+            paste(out, collapse = ","), ")"
+          )
+        )
+      }
+    }
+  }
+  expect_gt(checked, 500)
+})
+
+test_that("Both directions of merging are subset", {
+  spans <- list(
+    # rows 1 and 2 each carry a spanner over the first two columns
+    rows = matrix(
+      c(
+        2L, 0L, 1L,
+        2L, 0L, 1L,
+        1L, 1L, 1L
+      ),
+      nrow = 3,
+      byrow = TRUE
+    ),
+    # the last column is merged down its first two rows
+    columns = matrix(
+      c(
+        1L, 1L, 2L,
+        1L, 1L, 0L,
+        1L, 1L, 1L
+      ),
+      nrow = 3,
+      byrow = TRUE
+    )
+  )
+
+  # Dropping a column narrows the horizontal merges, on every row
+  kept_cols <- slice_spans(spans, 1:3, c(1, 3))
+  expect_equal(kept_cols$rows[1, ], c(1L, 1L))
+  expect_equal(kept_cols$rows[2, ], c(1L, 1L))
+  expect_equal(kept_cols$rows[3, ], c(1L, 1L))
+
+  # Dropping a row narrows the vertical merges
+  kept_rows <- slice_spans(spans, c(1, 3), 1:3)
+  expect_equal(kept_rows$columns[, 3], c(1L, 1L))
+  expect_equal(kept_rows$rows[1, ], c(2L, 0L, 1L))
+
+  # Keeping everything is a no op
+  whole <- slice_spans(spans, 1:3, 1:3)
+  expect_equal(whole$rows, spans$rows)
+  expect_equal(whole$columns, spans$columns)
+})
+
+test_that("Every header row is repaired over a column page break", {
+  # Both header rows carry a spanner that the column break cuts through
+  dat <- as.data.frame(matrix(as.character(1:10), nrow = 2))
+  names(dat) <- c("key", paste0("v", 1:4))
+
+  ct <- clintable(dat, use_labels = FALSE) |>
+    clin_alt_pages(
+      key_cols = "key",
+      col_groups = list(c("v1", "v2"), c("v3", "v4"))
+    ) |>
+    clin_column_headers(
+      key = c("", "Key"),
+      v1 = c("Top", "Second"),
+      v2 = c("Top", "Second"),
+      v3 = c("Top", "Second"),
+      v4 = c("Top", "Second")
+    )
+
+  expect_equal(ct$header$spans$rows[1, ], c(1L, 4L, 0L, 0L, 0L))
+  expect_equal(ct$header$spans$rows[2, ], c(1L, 4L, 0L, 0L, 0L))
+
+  ct2 <- prep_pagination_(ct)
+
+  for (p in ct2$clinify_config$pagination_idx) {
+    sliced <- slice_clintable(ct2, p$rows, p$cols)
+
+    # The lower header row used to be left holding a spanner four wide on a
+    # three column page
+    expect_equal(sliced$header$spans$rows[1, ], c(1L, 2L, 0L))
+    expect_equal(sliced$header$spans$rows[2, ], c(1L, 2L, 0L))
+  }
+})
+
+test_that("A page ending in a cut spanner slices cleanly", {
+  # The last page holds one column of a spanner that started on an earlier
+  # page, so the cell carrying the merge count is gone
+  dat <- as.data.frame(matrix(as.character(1:8), nrow = 2))
+  names(dat) <- c("key", paste0("v", 1:3))
+
+  ct <- clintable(dat, use_labels = FALSE) |>
+    clin_alt_pages(
+      key_cols = "key",
+      col_groups = list(c("v1", "v2"), "v3")
+    ) |>
+    clin_column_headers(
+      key = c("", "Key"),
+      v1 = c("Spanner", "a"),
+      v2 = c("Spanner", "b"),
+      v3 = c("Spanner", "c")
+    )
+
+  ct2 <- prep_pagination_(ct)
+  pages <- ct2$clinify_config$pagination_idx
+
+  # This used to error with "missing value where TRUE/FALSE needed"
+  slices <- lapply(pages, \(p) slice_clintable(ct2, p$rows, p$cols))
+
+  expect_equal(slices[[1]]$header$spans$rows[1, ], c(1L, 2L, 0L))
+  expect_equal(slices[[2]]$header$spans$rows[1, ], c(1L, 1L))
+
+  # And the spanner text is still on the page
+  expect_equal(
+    unname(unlist(slices[[2]]$header$dataset[1, ])),
+    c("", "Spanner")
+  )
+})
+
+test_that("Body merges survive a column page break", {
+  dat <- as.data.frame(matrix(as.character(1:16), nrow = 4))
+  names(dat) <- c("key", paste0("v", 1:3))
+
+  ct <- clintable(dat, use_labels = FALSE) |>
+    clin_alt_pages(
+      key_cols = "key",
+      col_groups = list(c("v1", "v2"), "v3")
+    )
+
+  # A full width section row, the way a section header is usually done, plus a
+  # merge down a column
+  ct <- flextable::merge_at(ct, i = 1, j = 1:4, part = "body")
+  ct <- flextable::merge_at(ct, i = 2:3, j = 1, part = "body")
+
+  ct2 <- prep_pagination_(ct)
+
+  for (p in ct2$clinify_config$pagination_idx) {
+    sliced <- slice_clintable(ct2, p$rows, p$cols)
+    width <- length(p$cols)
+
+    # The section row used to keep a merge four cells wide on a narrower page
+    expect_equal(sliced$body$spans$rows[1, ], c(width, rep(0L, width - 1L)))
+
+    # And the vertical merge is untouched by a column subset
+    expect_equal(sliced$body$spans$columns[, 1], c(1L, 2L, 0L, 1L))
+  }
+})
+
+test_that("Sliced pages always hold well formed merges", {
+  # Whatever the shape of the pagination, every page has to come out with
+  # merges that add up to the page it is on
+  well_formed <- function(v, width) {
+    if (sum(v) != width) {
+      return(FALSE)
+    }
+    i <- 1L
+    while (i <= length(v)) {
+      if (is.na(v[i]) || v[i] < 1 || i + v[i] - 1L > length(v)) {
+        return(FALSE)
+      }
+      if (v[i] > 1L && any(v[(i + 1L):(i + v[i] - 1L)] != 0)) {
+        return(FALSE)
+      }
+      i <- i + v[i]
+    }
+    TRUE
+  }
+
+  check_part <- function(part, label) {
+    for (i in seq_len(nrow(part$spans$rows))) {
+      expect_true(
+        well_formed(part$spans$rows[i, ], ncol(part$dataset)),
+        label = paste(label, "row", i)
+      )
+    }
+    for (j in seq_len(ncol(part$spans$columns))) {
+      expect_true(
+        well_formed(part$spans$columns[, j], nrow(part$dataset)),
+        label = paste(label, "column", j)
+      )
+    }
+  }
+
+  dat <- as.data.frame(matrix(as.character(1:48), nrow = 8))
+  names(dat) <- c("key", paste0("v", 1:5))
+  dat$GRP <- rep(c("a", "b"), each = 4)
+
+  # A spanner on every header row, a full width body row, and a merge running
+  # down a column - one of each way a merge can be cut
+  build <- function(col_groups) {
+    ct <- clintable(dat, use_labels = FALSE) |>
+      clin_group_by("GRP") |>
+      clin_alt_pages(key_cols = "key", col_groups = col_groups) |>
+      clin_column_headers(
+        key = c("", "", "Key"),
+        v1 = c("Top", "Middle", "leaf"),
+        v2 = c("Top", "Middle", "leaf"),
+        v3 = c("Top", "Middle", "leaf"),
+        v4 = c("Top", "Middle", "leaf"),
+        v5 = c("Top", "Middle", "leaf"),
+        GRP = c("", "", "")
+      )
+    ct <- flextable::merge_at(ct, i = 1, j = 1:6, part = "body")
+    flextable::merge_at(ct, i = 2:4, j = 1, part = "body")
+  }
+
+  col_group_shapes <- list(
+    list(c("v1", "v2"), c("v3", "v4", "v5")),
+    list("v1", "v2", "v3", "v4", "v5"),
+    list(c("v1", "v2", "v3", "v4"), "v5"),
+    list(c("v1", "v2", "v3", "v4", "v5"))
+  )
+
+  for (shape in col_group_shapes) {
+    ct <- prep_pagination_(build(shape))
+    label <- paste0("[", length(shape), " column groups]")
+
+    for (p in ct$clinify_config$pagination_idx) {
+      sliced <- slice_clintable(ct, p$rows, p$cols)
+      check_part(sliced$header, paste(label, "header"))
+      check_part(sliced$body, paste(label, "body"))
+    }
+  }
+})
+
+test_that("Merges running down a column survive a row page break", {
+  dat <- data.frame(
+    lbl = paste0("row", 1:8),
+    v1 = as.character(1:8),
+    v2 = as.character(11:18)
+  )
+
+  ct <- clintable(dat, use_labels = FALSE) |>
+    clin_page_by(max_rows = 4)
+
+  # A merge down the label column that runs straight through the page break
+  ct <- flextable::merge_at(ct, i = 2:6, j = 1, part = "body")
+  expect_equal(ct$body$spans$columns[, 1], c(1L, 5L, 0L, 0L, 0L, 0L, 1L, 1L))
+
+  ct2 <- prep_pagination_(ct)
+  pages <- ct2$clinify_config$pagination_idx
+  expect_length(pages, 2)
+
+  # Each page keeps only the part of the merge that is on it, and the count
+  # lands on the first row of that page rather than staying behind
+  expect_equal(
+    slice_clintable(ct2, pages[[1]]$rows, pages[[1]]$cols)$body$spans$columns[, 1],
+    c(1L, 3L, 0L, 0L)
+  )
+  expect_equal(
+    slice_clintable(ct2, pages[[2]]$rows, pages[[2]]$cols)$body$spans$columns[, 1],
+    c(2L, 0L, 1L, 1L)
+  )
 })

--- a/vignettes/clinify.Rmd
+++ b/vignettes/clinify.Rmd
@@ -206,6 +206,21 @@ The first parameter of `clin_column_headers()` will be the `clintable` object fo
 
 When using spanning headers, you're also typically using cell merging so that a single string of text spans over multiple columns. To accomplish this, repeat the text that you want to merge and ensure that those elements are placed in the same row. Consider the example above. For the Sepal variable, we have two spanning headers. One for "flowers", and one for "Sepal". These cells will be merged, and the bottom row contains "Length" and "Width" separately.
 
+Sometimes a header row repeats a label across adjacent columns without those columns being one spanner - a shift table where several columns each sit under their own treatment arm but share a "Baseline" sub-label, for example. Merging those cells would be wrong, so the `merge` argument lets you say which header rows should have their identical cells merged. `merge = "spanners"` covers the common case by leaving the bottom row of the header - the one holding the individual column labels - alone.
+
+```{r}
+clintable(iris) |>
+  clin_column_headers(
+    Sepal.Length = c("Flowers", "Sepal", "Value"),
+    Sepal.Width = c("Flowers", "Sepal", "Value"),
+    Petal.Length = c("Petal", "Value"),
+    Petal.Width = c("Petal", "Value"),
+    merge = "spanners"
+  )
+```
+
+Merging can also be turned off entirely with `merge = FALSE`, or aimed at specific header rows using ordinary R subscripts, numbered from the top down - `merge = 1:2` for the top two rows, or `merge = -3` for everything except the third. Since `merge` works a row at a time, a row that needs some of its repeated cells merged but not others should be left out of `merge` and spanned with `flextable::merge_at()` instead.
+
 Another common way you may want to apply headers is by using your variable labels. By default, clintable will respect this. Furthermore, the same spanning can be achieved as well. Let's consider another example:
 
 ```{r}
@@ -220,7 +235,20 @@ clintable(iris2) |>
   align(align = "center", part = "body")
 ```
 
-The underlying logic of this example is exactly the same as using `clin_column_headers()`, and in fact `clin_column_headers()` is actually called by default. The difference is that here, to separate levels we use the delimiter `||`. Note in this example how the spanning variable have also changed so that `Flower` stretches over all four Petal and Sepal columns. 
+The underlying logic of this example is exactly the same as using `clin_column_headers()`, and in fact the same header building machinery is applied by default. The difference is that here, to separate levels we use the delimiter `||`. Note in this example how the spanning variable have also changed so that `Flower` stretches over all four Petal and Sepal columns. 
+
+Headers built this way can have their merging adjusted too. Call `clin_column_headers()` with nothing but the `merge` argument and the header text coming from the labels is left as it is:
+
+```{r}
+iris3 <- iris
+attr(iris3$Sepal.Length, "label") <- "Flower||Sepal||Value"
+attr(iris3$Sepal.Width, "label") <- "Flower||Sepal||Value"
+attr(iris3$Petal.Length, "label") <- "Flower||Petal||Value"
+attr(iris3$Petal.Width, "label") <- "Flower||Petal||Value"
+
+clintable(iris3) |>
+  clin_column_headers(merge = "spanners")
+```
 
 Note that after headers are applied, additional styling can be done. In this case, we use the `flextable::align()` function to change the alignment on both the table body and column headers to center. Note that default styles are applied when the table is written out or printed, so these might potentially override some settings depending on how those functions are applied.
 


### PR DESCRIPTION
Closes #95.

## `clin_column_headers(merge = )`

`clin_column_headers()` ended with an unconditional `flextable::merge_h(part = "header")`, so every run of identical adjacent cells in every header row was merged. Correct for spanner rows, wrong for a leaf row that legitimately repeats a label across adjacent columns — the reported case being six columns each labelled `"Baseline"` under three treatment-arm spanners. The workaround was `merge_none(part = "header")` followed by re-doing the intended `merge_at()` calls by hand.

| `merge` | effect |
|---|---|
| `TRUE` / `"all"` | every header row — **unchanged default** |
| `"spanners"` | every row except the bottom one |
| `FALSE` / `"none"` | none |
| `1:2`, `-3`, `c(TRUE, TRUE, FALSE)` | header rows as ordinary R subscripts, numbered top down |

Called with only `merge` and no header text it re-merges the header already in place, which is how headers built from `||` column labels get an opt-out — they had none before, and `clintable(use_labels = TRUE)` is the default path.

Building the typology moved into an internal helper so `headers_from_labels_()` no longer goes through `do.call(clin_column_headers, args)`. A data column named `merge` is claimed by the new argument, so supplying `merge` on such a table now errors and points at column labels instead; that is the one narrow breaking change and it is noted in `NEWS.md`.

## Pre-existing bugs fixed in the same pass

Auditing the above turned up three reported bugs that shared one root cause, plus a fourth instance found while measuring. All reproduce on `development` and are independent of #95.

flextable stores a merge as a count on the first cell and `0` on each covered cell. `slice_complex_tabpart()` subset those matrices with a plain `[rows, columns]`, which is wrong whenever a subset cuts a merge: the count is left too wide, or the cell carrying it is dropped and the covered cells are orphaned. `adjust_span_row()` then tried to repair that from the already-sliced spans plus the cell text — information that is insufficient in principle, since two separate blocks sharing a label are indistinguishable from one split block once you are looking at the slice. It also risked re-merging exactly what `merge = FALSE` had separated.

Repair is now computed from the **unsliced** spans plus the retained indices: work out which merge each original cell belongs to, then count how many of each merge's cells survived. Text-independent, applied to every table part, and in both directions — `spans$rows` against retained columns, `spans$columns` against retained rows. `skip_spans` is gone; it existed to dodge the unreliable repair, and skipping it at `pagination.R:427` left invalid spans that the later per-page repair then computed *from*.

Separately, `as.matrix(apply(mheaders, 2, ...))` drops dims when the header is one level deep, so the `if (dim(mheaders)[2] > 1)` transpose guard was really testing "did `apply` return a matrix" and conflated depth 1 with ncol 1. The matrix is now built explicitly and always transposed.

### Measured against pristine `development`

| | before | after |
|---|---|---|
| Both header rows spanned, cut by a column break | header row 2 spans sum to 5 on a 3-column grid; **"Second" missing from page 2** | every row sums to the grid; text on both pages |
| Page ends in a cut spanner | **`write_clindoc()` errors** "missing value where TRUE/FALSE needed" | writes; spanner text on both pages |
| Full-width body section row + `clin_alt_pages()` | body row claims a 4-column span on 3- and 2-column pages | spans 3 and 2, matching each page |
| One-column table, 2-level header | 1 header row, **"Bottom" lost** | 2 rows, "Top"/"Bottom" |

## Verification

- **Brute force on the repair**: every well-formed span arrangement for widths 1–7 × every subset of retained positions, 10,795 cases — zero malformed outputs, zero block-membership violations, identity whenever nothing is dropped. A widths 1–5 version is committed as a test.
- **Invariant sweep over 480 pagination configurations** (column-group shapes including all-single-column, header depths 1–3, body merges, vertical merges, `group_by`, `page_by`): before → 324 config errors and **1,362 invalid spans**; after → **0 invalid spans**, with 6,768 slices reachable vs 1,872. The 36 residual config errors are identical on both sides and come from the sweep calling `prep_pagination_()` on `pagination_method == "default"` tables, which no render path does.
- **Mutation testing, 8 mutants, all caught**: collapsed block identity, count at the end of the run, subset ignored, axis swap, vertical repair removed, transpose guard restored, count off by one, blank-padding trick broken.
- `devtools::test()` — **1,870 pass, 0 fail, 0 skip**, and **zero snapshot changes**: the exact repair agrees with the old heuristic everywhere the old one was already right, including the `clin_alt_pages` snapshot test.
- `devtools::check()` — **0 errors, 0 warnings, 0 notes**, including vignette rebuild and examples.
- Lints on the three changed `R/` files: 36 → 34.

The obsolete `adjust_span_row()` unit test fed hand-built already-sliced vectors, inputs that can no longer arise, and is replaced with tests for the new contract — including an explicit assertion that never-merged cells stay never-merged through slicing, which is what stops pagination undoing `merge`.

## Notes for the reviewer

- Versioned as **0.4.0** (`DESCRIPTION`, `NEWS.md`, `cran-comments.md`). Minor rather than patch: a new user-facing feature, a narrow breaking change, and rendered `.docx` output changes for tables whose merges are cut by pagination. Kept in the minor slot rather than 1.0.0 since the package is still lifecycle experimental — 0.3.0 likewise carried breaking changes. `CRAN-SUBMISSION` is left alone; it is written at submission time.
- `cran-comments.md` states the local check result (0/0/0 on macOS, R 4.5.1) and points at the Actions matrix rather than asserting CI results — worth a final pass once CI on this PR is green.
- roxygen2 8.0.0 locally wants to swap `RoxygenNote: 7.3.2` for `Config/roxygen2/version`; that was reverted to keep it out of this diff.
- Also worth a look outside this repo: `CDISC_pilot_replication/tables/t_14_6_04.R` has the same header shape with no workaround, so its shipped `.docx` already collapses six `"Baseline"` cells into one. `merge = "spanners"` fixes it, and `t_14_6_05.R` / `t_14_6_06.R` can each drop four workaround lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

