### PR TITLE
Stop reading value labels as a variable label, and honour use_labels (#107)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# clinify (development version)
+
+- Fixed `clintable()` erroring on data carrying haven value labels. `attr()` partial matches, so a `labels` attribute of value labels - which `haven::read_xpt()` attaches to coded variables - was answering a request for `label` and being read as header text ([#107](https://github.com/atorus-research/clinify/issues/107))
+- Fixed `use_labels = FALSE` not actually leaving column labels alone. flextable reads labels of its own accord and was never told not to, so the raw label string went into the header, `||` delimiter and all. This also gives a way past the flextable side of #107, since labels can now be turned off ([#107](https://github.com/atorus-research/clinify/issues/107))
+
 # clinify 0.4.0
 
 - `clin_column_headers()` gained a `merge` argument to control the automatic merging of identical, adjacent header cells. Use `merge = "spanners"` to keep the bottom row of the header out of it, `merge = FALSE` to turn merging off entirely, or a vector of header row numbers for finer control. This lets a header row that legitimately repeats a label across adjacent columns keep those cells separate ([#95](https://github.com/atorus-research/clinify/issues/95))

--- a/R/clintable.R
+++ b/R/clintable.R
@@ -160,7 +160,10 @@ clintable <- function(
   }
 
   ct <- as_clintable(
-    flextable::flextable(x, ...),
+    # flextable reads column labels of its own accord, and would otherwise put
+    # the raw label string - "||" delimiter and all - into the header even when
+    # the caller asked for labels to be left alone
+    flextable::flextable(x, use_labels = use_labels, ...),
     page_by = page_by,
     group_by = group_by
   )

--- a/R/column_headers.R
+++ b/R/column_headers.R
@@ -382,8 +382,12 @@ headers_from_labels_ <- function(x, merge = TRUE) {
   refdat <- x$body$dataset
   if (has_labels_(refdat)) {
     args <- lapply(refdat, \(x) {
-      if (!is.null(attr(x, "label"))) {
-        unlist(strsplit(attr(x, "label"), "||", fixed = TRUE))
+      # exact = TRUE, or a `labels` attribute of value labels answers a request
+      # for `label` and gets read as header text
+      label <- attr(x, "label", exact = TRUE)
+
+      if (!is.null(label)) {
+        unlist(strsplit(label, "||", fixed = TRUE))
       } else {
         ""
       }
@@ -400,5 +404,8 @@ headers_from_labels_ <- function(x, merge = TRUE) {
 #' Do any of the dataframe variables have labels?
 #' @noRd
 has_labels_ <- function(x) {
-  any(vapply(x, \(y) !is.null(attr(y, "label")), FALSE))
+  # exact = TRUE, because attr() otherwise partial matches - haven attaches a
+  # `labels` attribute of value labels to coded variables, and that would
+  # answer a request for `label` and be mistaken for a variable label
+  any(vapply(x, \(y) !is.null(attr(y, "label", exact = TRUE)), FALSE))
 }

--- a/tests/testthat/test-clintable.R
+++ b/tests/testthat/test-clintable.R
@@ -245,3 +245,59 @@ test_that("as_clintable has no coerce_character, but has a substitute", {
     c("86", "75.2")
   )
 })
+
+test_that("Value labels are not mistaken for a variable label", {
+  # haven attaches a `labels` attribute of value labels to coded variables, and
+  # attr() partial matches, so a request for `label` was being answered by
+  # `labels` and read as header text (#107)
+  d <- data.frame(a = 1:2, b = 3:4)
+  attr(d$a, "labels") <- c(Low = 1, High = 2)
+
+  expect_false(has_labels_(d))
+
+  # A real variable label is still found
+  d2 <- data.frame(v = 1)
+  attr(d2$v, "label") <- "Treatment A||(N=86)"
+  expect_true(has_labels_(d2))
+  expect_equal(nrow(clintable(d2)$header$dataset), 2)
+
+  # And when a column carries both, the real label is the one used
+  d3 <- data.frame(v = 1)
+  attr(d3$v, "labels") <- c(A = 1)
+  attr(d3$v, "label") <- "Real||Label"
+  expect_equal(
+    unname(unlist(clintable(d3)$header$dataset)),
+    c("Real", "Label")
+  )
+})
+
+test_that("use_labels = FALSE really leaves labels alone", {
+  # flextable reads column labels of its own accord, so without being told not
+  # to it put the raw label string, delimiter and all, into the header even
+  # when the caller had asked for labels to be left alone
+  d <- data.frame(lbl = "Male", val = 86)
+  attr(d$val, "label") <- "Treatment A||(N=86)"
+
+  rendered <- function(ct) {
+    flextable:::information_data_chunk(ct)$txt
+  }
+
+  expect_false(any(grepl("Treatment A", rendered(clintable(d, use_labels = FALSE)))))
+  expect_true(any(grepl("Treatment A", rendered(clintable(d)))))
+
+  # Which also gives a way past the flextable side of #107
+  coded <- data.frame(a = 1:2)
+  attr(coded$a, "labels") <- c(Low = 1, High = 2)
+  expect_no_error(clintable(coded, use_labels = FALSE))
+})
+
+test_that("Value labels still reach the cells when labels are wanted", {
+  # Turning labels off must not be the only way to render a table, so the
+  # flextable behaviour clinify relies on has to stay intact
+  d <- data.frame(v = c(1, 2))
+  attr(d$v, "label") <- "Sex"
+  attr(d$v, "labels") <- c(Male = 1, Female = 2)
+
+  txt <- flextable:::information_data_chunk(clintable(d))$txt
+  expect_true(all(c("Male", "Female") %in% txt))
+})


### PR DESCRIPTION
Closes #107.

## The reported crash

`attr()` partial matches. A `labels` attribute — the value labels `haven::read_xpt()` attaches to coded ADaM variables — was answering a request for `label`, so `has_labels_()` reported a variable label that was never there and the header machinery tried to treat a named *numeric* vector as header text:

```r
d <- data.frame(a = 1:2); attr(d$a, "labels") <- c(Low = 1, High = 2)
clintable(d)
#> Error in `labelizor()`: `labels` must be a named character vector or a function.
```

Both reads now ask for the attribute exactly. A real `label` still works, and a column carrying both still uses the real one.

## But that is only half of it, and the other half was a second bug

Fixing `has_labels_()` did **not** stop the crash — because flextable reads column labels of its own accord and clinify never told it not to. `flextable:::collect_labels()` partial matches the same way, so the error was coming from upstream.

Which exposed a separate bug: **`use_labels = FALSE` did not leave labels alone.** The flag gated only clinify's own header building; flextable's `use_labels` defaults to `TRUE`, so the raw label string went into the header, `||` delimiter and all:

```r
attr(d$val, "label") <- "Treatment A||(N=86)"
clintable(d, use_labels = FALSE)
#> rendered header: "lbl" | "Treatment A||(N=86)"
```

And there was no way to ask for anything else — passing `use_labels` through `...` errors as a duplicate argument. The flag is now forwarded, so it means the same thing for both packages, and `use_labels = FALSE` gives bare column names as it says.

I should flag that I got this wrong the first time I looked at it: I checked `$header$dataset` (which shows bare names) rather than the rendered chunk text, and reported the behaviour as correct. It wasn't. This is also why three pilot programs carry `attr(x, "label") <- NULL` on top of everything else.

## What is left upstream

`use_labels = TRUE` on a value-labelled column still errors, inside flextable. Forwarding the flag at least means **turning labels off is now a genuine escape hatch where before there was none.** Worth reporting to flextable — `collect_labels()` needs `exact = TRUE` for `variables_labels`.

Value label rendering is deliberately untouched: a column carrying both a variable label and value labels still renders its values as the labels, which is exactly why clinify should not simply switch flextable's handling off.

## Verification

- 2,115 tests pass, zero snapshot changes.
- New tests: a `labels`-only column is not seen as labelled; a real label still builds a multi-level header; both attributes present uses the real one; `use_labels = FALSE` really suppresses labels; and value labels still reach the cells when labels are wanted.
- `devtools::check()` — 0 errors, 0 warnings, **1 NOTE**: `checking for future file timestamps ... unable to verify current time`. That is the no-network-access note this repo's own `cran-comments.md` already documents as local-only; earlier checks in the same session were 0/0/0.

## Note

`DESCRIPTION` left at 0.4.0 with the entries under `# clinify (development version)` — 0.4.0 is on `main` but not yet on CRAN, so whether these fold into 0.4.0 or become 0.4.1 is your call at release time. #101 and #113 do the same, so expect a one-line NEWS merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
