### PR TITLE
Keep the header spacing when the column headers are set (#101)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# clinify (development version)
+
+- Fixed the spacing clinify starts a column header with being lost as soon as the headers were set. Setting them rebuilds the header part, which dropped the padding applied at construction, so a table with custom headers or `||` column labels sat on flextable's own default while a plain one kept clinify's. It is applied as a starting point, so a later `flextable::padding()` or `clin_header_pad()` still wins ([#101](https://github.com/atorus-research/clinify/issues/101))
+
 # clinify 0.4.0
 
 - `clin_column_headers()` gained a `merge` argument to control the automatic merging of identical, adjacent header cells. Use `merge = "spanners"` to keep the bottom row of the header out of it, `merge = FALSE` to turn merging off entirely, or a vector of header row numbers for finer control. This lets a header row that legitimately repeats a label across adjacent columns keep those cells separate ([#95](https://github.com/atorus-research/clinify/issues/95))

--- a/R/clintable.R
+++ b/R/clintable.R
@@ -49,13 +49,7 @@ as_clintable <- function(x, page_by = NULL, group_by = NULL) {
     padding.bottom = 0.1,
     padding.top = 0.1
   )
-  x <- flextable::padding(x, i = 1, part = "header", padding.top = 9)
-  x <- flextable::padding(
-    x,
-    i = flextable::nrow_part(x, part = "header"),
-    part = "header",
-    padding.bottom = 9
-  )
+  x <- default_header_pad_(x)
 
   class(x) <- c("clintable", "flextable")
   x
@@ -195,4 +189,32 @@ coerce_character_ <- function(x) {
     col
   })
   x
+}
+
+#' The spacing clinify starts a header block with
+#'
+#' Setting the column headers rebuilds the header part from scratch, which
+#' drops the padding put on it at construction, so this is applied again
+#' afterwards rather than only once. Being a starting point it is set before
+#' anything the caller does, so a later `flextable::padding()` or
+#' [clin_header_pad()] still wins.
+#'
+#' @param x A clintable object
+#'
+#' @return A clintable object
+#'
+#' @noRd
+default_header_pad_ <- function(x) {
+  if (flextable::nrow_part(x, part = "header") < 1) {
+    return(x)
+  }
+
+  x <- flextable::padding(x, i = 1, part = "header", padding.top = 9)
+
+  flextable::padding(
+    x,
+    i = flextable::nrow_part(x, part = "header"),
+    part = "header",
+    padding.bottom = 9
+  )
 }

--- a/R/column_headers.R
+++ b/R/column_headers.R
@@ -233,6 +233,10 @@ apply_column_headers_ <- function(x, args, merge = TRUE) {
   # Apply to the clintable
   x <- flextable::set_header_df(x, typology)
 
+  # set_header_df() rebuilds the header part, so the spacing clinify starts a
+  # header with has just been dropped and needs putting back
+  x <- default_header_pad_(x)
+
   # Merging is resolved against the header rows that actually landed on the
   # table, which is not always the number of levels asked for
   remerge_header_(x, merge, clear = FALSE)

--- a/tests/testthat/test-clintable.R
+++ b/tests/testthat/test-clintable.R
@@ -245,3 +245,48 @@ test_that("as_clintable has no coerce_character, but has a substitute", {
     c("86", "75.2")
   )
 })
+
+test_that("Setting column headers keeps the spacing clinify starts them with", {
+  # Setting the headers rebuilds the header part, which dropped the padding put
+  # on it at construction and left a custom-header table on flextable's own
+  # default while a plain one kept clinify's (#101)
+  pad <- function(ct) {
+    list(
+      top = unname(ct$header$styles$pars$padding.top$data[, 1]),
+      bottom = unname(ct$header$styles$pars$padding.bottom$data[, 1])
+    )
+  }
+
+  plain <- pad(clintable(mtcars))
+  expect_equal(plain$top, 9)
+  expect_equal(plain$bottom, 9)
+
+  # A two level header carries it on the outside of the block, top of the first
+  # row and bottom of the last
+  custom <- pad(clin_column_headers(clintable(mtcars), mpg = c("A", "B")))
+  expect_equal(custom$top, c(9, 5))
+  expect_equal(custom$bottom, c(5, 9))
+
+  # Same when the header came from column labels, which is the default path
+  labelled <- mtcars
+  attr(labelled$mpg, "label") <- "Miles||per gallon"
+  expect_equal(pad(clintable(labelled))$top, c(9, 5))
+
+  # It is a starting point, so anything the caller does afterwards still wins
+  by_hand <- flextable::padding(
+    clin_column_headers(clintable(mtcars), mpg = c("A", "B")),
+    i = 1,
+    part = "header",
+    padding.top = 21
+  )
+  expect_equal(pad(by_hand)$top, c(21, 5))
+
+  configured <- finish_table_(
+    clin_header_pad(
+      clin_column_headers(clintable(mtcars), mpg = c("A", "B")),
+      above = 18,
+      below = 4
+    )
+  )
+  expect_equal(unique(pad(configured)$top), 18)
+})


### PR DESCRIPTION
Closes #101.

`as_clintable()` puts 9 points above the first header row and 9 below the last, but setting the column headers rebuilds the header part and that dropped it. So a plain clintable kept clinify's spacing while any table with custom headers **or a `||` column label — the default path** — silently sat on flextable's 5pt default:

| how the table was built | before | after |
|---|---|---|
| `clintable(mtcars)` | `top=9 bottom=9` | unchanged |
| `+ clin_column_headers()` | `top=5 bottom=5` | `top=9,5 bottom=5,9` |
| `clintable(df)` with a `\|\|` label | `top=5 bottom=5` | `top=9,5 bottom=5,9` |

Confirmed in rendered output, not just in the object — a custom-header table's docx went from `5/5 5/5` to `9/5 5/9` paragraph spacing, which is the "9 on the outside of the block" the constructor intends.

The padding is now factored into one helper and applied again after the header is rebuilt. It stays a **starting point**, applied before anything the caller does, so ordering is preserved:

- a later `flextable::padding(i = 1, padding.top = 21)` still wins → `21,5`
- `clin_header_pad(above = 18, below = 4)` still wins → `18/4`

Both are pinned by tests.

## On the snapshot churn I predicted

There wasn't any. I flagged this as "not a quiet fix" when filing, expecting the HTML snapshots to move — **2,114 tests pass with zero snapshot changes.** The reason is that none of the existing snapshots capture header paragraph spacing, which is worth knowing on its own: this change is user-visible in the .docx and no snapshot would have caught a regression in it. Hence the explicit test.

`devtools::check()` — 0 errors, 0 warnings, 0 notes.

## Note

`DESCRIPTION` left at 0.4.0 with the entry under `# clinify (development version)`, same as #107 and #113 — expect a one-line NEWS merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
